### PR TITLE
JDNS: fixes due to static code analysis

### DIFF
--- a/include/jdns/qjdnsshared.h
+++ b/include/jdns/qjdnsshared.h
@@ -242,7 +242,7 @@ public:
 	/**
 	   \brief Perform a query operation
 	*/
-	void query(const QByteArray &name, int type);
+    void query(const QByteArray &name, QJDns::Type type);
 
 	/**
 	   \brief Perform a publish operation

--- a/src/jdns/jdns.c
+++ b/src/jdns/jdns.c
@@ -316,14 +316,14 @@ static void _print_hexdump(jdns_session_t *s, const unsigned char *buf, int size
 {
 	int n;
 	int lines;
-	int at, len;
+    int len;
 
 	lines = size / 16;
 	if(size % 16 != 0)
 		++lines;
 	for(n = 0; n < lines; ++n)
 	{
-		at = n * 16;
+        int at = n * 16;
 		if(at + 16 <= size)
 			len = 16;
 		else
@@ -348,7 +348,6 @@ static void _print_packet_resources(jdns_session_t *s, const jdns_list_t *reslis
 
 static void _print_packet(jdns_session_t *s, const jdns_packet_t *packet)
 {
-	int n;
 	_debug_line(s, "Packet:");
 	_debug_line(s, "  id:   %d", packet->id);
 	_debug_line(s, "  opts: qr:%d, opcode:%d, aa:%d, tc:%d, rd:%d, ra:%d, z:%d, rcode:%d",
@@ -358,7 +357,8 @@ static void _print_packet(jdns_session_t *s, const jdns_packet_t *packet)
 		packet->qdcount, packet->ancount, packet->nscount, packet->arcount);
 	if(packet->questions->count > 0)
 	{
-		_debug_line(s, "  questions: (class/type name)");
+        _debug_line(s, "  questions: (class/type name)");
+        int n;
 		for(n = 0; n < packet->questions->count; ++n)
 		{
 			jdns_packet_question_t *q;
@@ -388,7 +388,6 @@ static void _print_packet(jdns_session_t *s, const jdns_packet_t *packet)
 
 static void _print_rr(jdns_session_t *s, const jdns_rr_t *rr, const unsigned char *owner)
 {
-	int n;
 	jdns_string_t *ownerstr;
 
 	ownerstr = jdns_string_new();
@@ -453,7 +452,8 @@ static void _print_rr(jdns_session_t *s, const jdns_rr_t *rr, const unsigned cha
 		case JDNS_RTYPE_TXT:
 		{
 			_debug_line(s, "    TXT: count=%d (ttl=%d)%s", rr->data.texts->count, rr->ttl, ownerstr->data);
-			for(n = 0; n < rr->data.texts->count; ++n)
+            int n;
+            for(n = 0; n < rr->data.texts->count; ++n)
 			{
 				jdns_string_t *str, *pstr;
 				str = rr->data.texts->item[n];
@@ -1658,11 +1658,11 @@ jdns_response_t *_cache_get_response(jdns_session_t *s, const unsigned char *qna
 
 query_t *_find_first_active_query(jdns_session_t *s, const unsigned char *qname, int qtype)
 {
-	int n;
-	query_t *q;
+    int n;
 
 	for(n = 0; n < s->queries->count; ++n)
 	{
+        query_t *q;
 		q = (query_t *)s->queries->item[n];
 		if(jdns_domain_cmp(q->qname, qname) && q->qtype == qtype && q->step != -1)
 			return q;
@@ -2349,7 +2349,6 @@ int _unicast_do_reads(jdns_session_t *s, int now)
 
 void _process_message(jdns_session_t *s, jdns_packet_t *packet, int now, query_t *q, name_server_t *ns)
 {
-	int n;
 	int authoritative;
 	int truncated;
 	int recursion_desired;
@@ -2439,6 +2438,7 @@ void _process_message(jdns_session_t *s, jdns_packet_t *packet, int now, query_t
 
 		if(cache_answers)
 		{
+            int n;
 			for(n = 0; n < r->answerCount; ++n)
 			{
 				jdns_rr_t *record = r->answerRecords[n];
@@ -2448,6 +2448,7 @@ void _process_message(jdns_session_t *s, jdns_packet_t *packet, int now, query_t
 
 		if(cache_additional)
 		{
+            int n;
 			for(n = 0; n < r->additionalCount; ++n)
 			{
 				jdns_rr_t *record = r->additionalRecords[n];
@@ -2491,7 +2492,7 @@ int _process_response(jdns_session_t *s, jdns_response_t *r, int nxdomain, int n
 	int do_nxdomain = 0;
 
 	// error
-	if(!r)
+    if(!r)
 	{
 		int all_errored;
 
@@ -2773,8 +2774,7 @@ int _multicast_query_ans(mdnsda a, void *arg)
 	jdns_session_t *s;
 	query_t *q;
 	jdns_response_t *r;
-	jdns_rr_t *rr;
-	jdns_event_t *event;
+    jdns_rr_t *rr;
 
 	s = (jdns_session_t *)arg;
 
@@ -2824,6 +2824,7 @@ int _multicast_query_ans(mdnsda a, void *arg)
 	// report event to any requests listening
 	for(n = 0; n < q->req_ids_count; ++n)
 	{
+        jdns_event_t *event;
 		event = jdns_event_new();
 		event->type = JDNS_EVENT_RESPONSE;
 		event->id = q->req_ids[n];

--- a/src/jdns/jdns_mdnsd.c
+++ b/src/jdns/jdns_mdnsd.c
@@ -148,10 +148,11 @@ void mdnsda_content_free(struct mdnsda_struct *rr)
 int _namehash(const char *s)
 {
     const unsigned char *name = (const unsigned char *)s;
-    unsigned long h = 0, g;
+    unsigned long h = 0;
 
     while (*name)
     { /* do some fancy bitwanking on the string */
+        unsigned long g;
         h = (h << 4) + (unsigned long)(*name++);
         if ((g = (h & 0xF0000000UL))!=0)
             h ^= (g >> 24);
@@ -625,10 +626,10 @@ int _r_out(mdnsd d, struct message *m, mdnsdr *list)
 int _r_out(mdnsd d, jdns_packet_t *m, mdnsdr *list)
 { // copy a published record into an outgoing message
     mdnsdr r; //, next;
-    unsigned short class;
     int ret = 0;
     while((r = *list) != 0)
     {
+        unsigned short class;
         *list = r->list;
         ret++;
         class = r->unique ? d->class | 0x8000 : d->class;
@@ -735,7 +736,7 @@ void mdnsd_free(mdnsd d)
 
 void mdnsd_in(mdnsd d, const jdns_packet_t *m, const jdns_response_t *resp, const jdns_address_t *addr, unsigned short int port)
 {
-    int i, j;
+    int i;
     mdnsdr r = 0;
 
     if(d->shutdown) return;
@@ -755,6 +756,7 @@ void mdnsd_in(mdnsd d, const jdns_packet_t *m, const jdns_response_t *resp, cons
 
             for(;r != 0; r = _r_next(d,r,(char *)pq->qname->data,pq->qtype))
             { // check all of our potential answers
+                int j;
                 if(r->unique && r->unique < 5)
                 { // probing state, check for conflicts
                     for(j=0;j<resp->authorityCount;j++)
@@ -843,9 +845,9 @@ int mdnsd_out(mdnsd d, jdns_packet_t **_m, jdns_address_t **addr, unsigned short
     if(d->a_publish && _tvdiff(d->now,d->publish) <= 0)
     { // check to see if it's time to send the publish retries (and unlink if done)
         mdnsdr next, cur = d->a_publish, last = 0;
-        unsigned short class;
         while(cur /*&& message_packet_len(m) + _rr_len(&cur->rr) < d->frame*/ )
         {
+            unsigned short class;
             next = cur->list;
             ret++; cur->tries++;
             class = cur->unique ? d->class | 0x8000 : d->class;
@@ -1013,10 +1015,10 @@ struct mytimeval *mdnsd_sleep(mdnsd d)
 void mdnsd_query(mdnsd d, char *host, int type, int (*answer)(mdnsda a, void *arg), void *arg)
 {
     struct query *q;
-    struct cached *cur = 0;
     int i = _namehash_nocase(host) % SPRIME;
     if(!(q = _q_next(d,0,host,type)))
     {
+        struct cached *cur = 0;
         if(!answer) return;
         q = (struct query *)jdns_alloc(sizeof(struct query));
         bzero(q,sizeof(struct query));

--- a/src/jdns/jdns_packet.c
+++ b/src/jdns/jdns_packet.c
@@ -291,7 +291,7 @@ static int matchlabel(const unsigned char *a, int asize, const unsigned char *b,
 
 int jdns_packet_name_isvalid(const unsigned char *name, int size)
 {
-	int n, at, len;
+    int n, at;
 
 	// at least one byte, no larger than MAX_LABEL_LENGTH - 1 (one byte is
 	//   gained when converting to a label)
@@ -310,6 +310,7 @@ int jdns_packet_name_isvalid(const unsigned char *name, int size)
 	at = 0;
 	while(1)
 	{
+        int len;
 		// search for dot or end
 		for(n = at; n < size; ++n)
 		{
@@ -332,7 +333,7 @@ int jdns_packet_name_isvalid(const unsigned char *name, int size)
 // this function assumes label is pointing to a MAX_LABEL_LENGTH byte buffer
 static int name_to_label(const jdns_string_t *name, unsigned char *label)
 {
-	int n, i, at, len;
+    int n, i, at;
 
 	if(!jdns_packet_name_isvalid(name->data, name->size))
 		return -1;
@@ -347,6 +348,7 @@ static int name_to_label(const jdns_string_t *name, unsigned char *label)
 	i = 0;
 	while(1)
 	{
+        int len;
 		// search for dot or end
 		for(n = at; n < name->size; ++n)
 		{

--- a/src/jdns/jdns_sys.c
+++ b/src/jdns/jdns_sys.c
@@ -303,11 +303,7 @@ static jdns_string_t *file_nextline(FILE *f)
 static jdns_dnshostlist_t *read_hosts_file(const char *path)
 {
 	jdns_dnshostlist_t *out;
-	FILE *f;
-	jdns_string_t *line, *simp;
-	jdns_stringlist_t *parts;
-	jdns_address_t *addr;
-	int n;
+    FILE *f;
 
 	out = jdns_dnshostlist_new();
 
@@ -315,8 +311,13 @@ static jdns_dnshostlist_t *read_hosts_file(const char *path)
 	if(!f)
 		return out;
 	while(1)
-	{
-		line = file_nextline(f);
+    {
+        jdns_string_t *line, *simp;
+        jdns_stringlist_t *parts;
+        jdns_address_t *addr;
+        int n;
+
+        line = file_nextline(f);
 		if(!line)
 			break;
 
@@ -658,11 +659,8 @@ static jdns_dnsparams_t *dnsparams_get_win()
 
 static jdns_dnsparams_t *dnsparams_get_unixfiles()
 {
-	FILE *f;
-	int n;
-	jdns_dnsparams_t *params;
-	jdns_string_t *line, *simp;
-	jdns_stringlist_t *parts;
+    FILE *f;
+    jdns_dnsparams_t *params;
 
 	params = jdns_dnsparams_new();
 
@@ -671,6 +669,10 @@ static jdns_dnsparams_t *dnsparams_get_unixfiles()
 		return params;
 	while(1)
 	{
+        int n;
+        jdns_string_t *line, *simp;
+        jdns_stringlist_t *parts;
+
 		line = file_nextline(f);
 		if(!line)
 			break;

--- a/src/jdns/jdns_util.c
+++ b/src/jdns/jdns_util.c
@@ -385,15 +385,18 @@ int jdns_string_indexOf(const jdns_string_t *s, unsigned char c, int pos)
 
 jdns_stringlist_t *jdns_string_split(const jdns_string_t *s, unsigned char sep)
 {
-	int at, n, len;
-	jdns_string_t *str;
+    int at;
 	jdns_stringlist_t *out;
 
 	at = 0;
 	out = jdns_stringlist_new();
 	while(at < s->size)
 	{
-		n = jdns_string_indexOf(s, sep, at);
+        int len;
+        int n;
+        jdns_string_t *str;
+
+        n = jdns_string_indexOf(s, sep, at);
 		if(n == -1)
 			n = s->size;
 		len = n - at;
@@ -605,18 +608,19 @@ error:
 	}
 	else if(strchr(str, '.'))
 	{
-		unsigned char b[4];
-		int x;
+        unsigned char b[4];
 		unsigned long int ipv4;
-		int at;
-		char *part;
-		int len;
+        int at;
 		const char *p, *p2;
 
 		p = str;
 		at = 0;
 		while(1)
 		{
+            int x;
+            char *part;
+            int len;
+
 			p2 = strchr(p, '.');
 			if(!p2)
 				p2 = str + slen;
@@ -792,12 +796,12 @@ jdns_nameserverlist_t *jdns_nameserverlist_new()
 
 jdns_nameserverlist_t *jdns_nameserverlist_copy(const jdns_nameserverlist_t *a)
 {
-	int n;
 	jdns_nameserverlist_t *c = jdns_nameserverlist_new();
 	if(a->item)
 	{
+        int n;
 		c->item = (jdns_nameserver_t **)jdns_alloc(sizeof(jdns_nameserver_t *) * a->count);
-		c->count = a->count;
+        c->count = a->count;
 		for(n = 0; n < c->count; ++n)
 			c->item[n] = jdns_nameserver_copy(a->item[n]);
 	}
@@ -806,11 +810,11 @@ jdns_nameserverlist_t *jdns_nameserverlist_copy(const jdns_nameserverlist_t *a)
 
 void jdns_nameserverlist_delete(jdns_nameserverlist_t *a)
 {
-	int n;
 	if(!a)
 		return;
 	if(a->item)
 	{
+        int n;
 		for(n = 0; n < a->count; ++n)
 			jdns_nameserver_delete(a->item[n]);
 		jdns_free(a->item);
@@ -872,10 +876,10 @@ jdns_dnshostlist_t *jdns_dnshostlist_new()
 
 jdns_dnshostlist_t *jdns_dnshostlist_copy(const jdns_dnshostlist_t *a)
 {
-	int n;
 	jdns_dnshostlist_t *c = jdns_dnshostlist_new();
 	if(a->item)
 	{
+        int n;
 		c->item = (jdns_dnshost_t **)jdns_alloc(sizeof(jdns_dnshost_t *) * a->count);
 		c->count = a->count;
 		for(n = 0; n < c->count; ++n)
@@ -886,11 +890,11 @@ jdns_dnshostlist_t *jdns_dnshostlist_copy(const jdns_dnshostlist_t *a)
 
 void jdns_dnshostlist_delete(jdns_dnshostlist_t *a)
 {
-	int n;
 	if(!a)
 		return;
 	if(a->item)
 	{
+        int n;
 		for(n = 0; n < a->count; ++n)
 			jdns_dnshost_delete(a->item[n]);
 		jdns_free(a->item);
@@ -1359,14 +1363,14 @@ jdns_rr_t *jdns_rr_from_resource(const jdns_packet_resource_t *pr, const jdns_pa
 		}
 		case JDNS_RTYPE_TXT:
 		{
-			jdns_stringlist_t *texts;
-			jdns_string_t *str;
+            jdns_stringlist_t *texts;
 			int at, error;
 			texts = jdns_stringlist_new();
 			at = 0;
 			error = 0;
 			while(at < pr->rdlength)
 			{
+                jdns_string_t *str;
 				str = read_text_string(pr, &at);
 				if(!str)
 				{

--- a/src/qjdns/qjdns.cpp
+++ b/src/qjdns/qjdns.cpp
@@ -622,7 +622,7 @@ void QJDns::Private::removeCancelled(int id)
 
 void QJDns::Private::udp_readyRead()
 {
-	QUdpSocket *sock = (QUdpSocket *)sender();
+    QUdpSocket *sock = static_cast<QUdpSocket *>(sender());
 	int handle = handleForSocket.value(sock);
 
 	if(need_handle)

--- a/src/qjdns/qjdnsshared.cpp
+++ b/src/qjdns/qjdnsshared.cpp
@@ -297,6 +297,8 @@ QStringList QJDnsSharedDebug::readDebugLines()
 QJDnsSharedPrivate::QJDnsSharedPrivate(QJDnsShared *_q)
 	: QObject(_q)
 	, q(_q)
+    , shutting_down(false)
+    , db(NULL)
 {
 }
 
@@ -465,7 +467,12 @@ void QJDnsSharedPrivate::late_shutdown()
 	emit q->shutdownFinished();
 }
 
-QJDnsSharedRequestPrivate::QJDnsSharedRequestPrivate(QJDnsSharedRequest *_q) : QObject(_q), q(_q), lateTimer(this)
+QJDnsSharedRequestPrivate::QJDnsSharedRequestPrivate(QJDnsSharedRequest *_q) : QObject(_q)
+  , q(_q)
+  , lateTimer(this)
+  , jsp(NULL)
+  , qType(QJDns::A)
+  , success(false)
 {
 	connect(&lateTimer, SIGNAL(timeout()), SLOT(lateTimer_timeout()));
 }
@@ -502,7 +509,7 @@ QJDnsSharedRequest::Type QJDnsSharedRequest::type()
 	return d->type;
 }
 
-void QJDnsSharedRequest::query(const QByteArray &name, int type)
+void QJDnsSharedRequest::query(const QByteArray &name, QJDns::Type type)
 {
 	cancel();
 	d->jsp->queryStart(this, name, type);
@@ -817,7 +824,7 @@ void QJDnsSharedPrivate::removeInterface(const QHostAddress &addr)
 	addDebug(index, QString("removing from %1").arg(addr.toString()));
 }
 
-void QJDnsSharedPrivate::queryStart(QJDnsSharedRequest *obj, const QByteArray &name, int qType)
+void QJDnsSharedPrivate::queryStart(QJDnsSharedRequest *obj, const QByteArray &name, QJDns::Type qType)
 {
 	obj->d->type = QJDnsSharedRequest::Query;
 	obj->d->success = false;
@@ -1010,7 +1017,7 @@ void QJDnsSharedPrivate::publishCancel(QJDnsSharedRequest *obj)
 
 void QJDnsSharedPrivate::jdns_resultsReady(int id, const QJDns::Response &results)
 {
-	QJDns *jdns = (QJDns *)sender();
+    QJDns *jdns = static_cast<QJDns *>(sender());
 	QJDnsSharedRequest *obj = findRequest(jdns, id);
 	Q_ASSERT(obj);
 
@@ -1091,7 +1098,7 @@ void QJDnsSharedPrivate::jdns_resultsReady(int id, const QJDns::Response &result
 
 void QJDnsSharedPrivate::jdns_published(int id)
 {
-	QJDns *jdns = (QJDns *)sender();
+    QJDns *jdns = static_cast<QJDns *>(sender());
 	QJDnsSharedRequest *obj = findRequest(jdns, id);
 	Q_ASSERT(obj);
 
@@ -1125,7 +1132,7 @@ void QJDnsSharedPrivate::jdns_published(int id)
 
 void QJDnsSharedPrivate::jdns_error(int id, QJDns::Error e)
 {
-	QJDns *jdns = (QJDns *)sender();
+    QJDns *jdns = static_cast<QJDns *>(sender());
 	QJDnsSharedRequest *obj = findRequest(jdns, id);
 	Q_ASSERT(obj);
 
@@ -1186,7 +1193,7 @@ void QJDnsSharedPrivate::jdns_error(int id, QJDns::Error e)
 
 void QJDnsSharedPrivate::jdns_shutdownFinished()
 {
-	QJDns *jdns = (QJDns *)sender();
+    QJDns *jdns = static_cast<QJDns *>(sender());
 
 	addDebug(instanceForQJDns.value(jdns)->index, "jdns_shutdownFinished, removing interface");
 
@@ -1202,7 +1209,7 @@ void QJDnsSharedPrivate::jdns_shutdownFinished()
 
 void QJDnsSharedPrivate::jdns_debugLinesReady()
 {
-	QJDns *jdns = (QJDns *)sender();
+    QJDns *jdns = static_cast<QJDns *>(sender());
 
 	doDebug(jdns, instanceForQJDns.value(jdns)->index);
 }

--- a/src/qjdns/qjdnsshared_p.h
+++ b/src/qjdns/qjdnsshared_p.h
@@ -142,7 +142,9 @@ public:
 		QHostAddress addr;
 		int index;
 
-		Instance() : jdns(0)
+        Instance() :
+            jdns(0),
+            index(0)
 		{
 		}
 	};
@@ -178,7 +180,7 @@ public:
 	bool addInterface(const QHostAddress &addr);
 	void removeInterface(const QHostAddress &addr);
 
-	void queryStart(QJDnsSharedRequest *obj, const QByteArray &name, int qType);
+    void queryStart(QJDnsSharedRequest *obj, const QByteArray &name, QJDns::Type qType);
 	void queryCancel(QJDnsSharedRequest *obj);
 	void publishStart(QJDnsSharedRequest *obj, QJDns::PublishMode m, const QJDns::Record &record);
 	void publishUpdate(QJDnsSharedRequest *obj, const QJDns::Record &record);
@@ -205,7 +207,7 @@ public:
 	// current action
 	QJDnsSharedRequest::Type type;
 	QByteArray name;
-	int qType;
+    QJDns::Type qType;
 	QJDns::PublishMode pubmode;
 	QJDnsSharedPrivate::PreprocessMode ppmode;
 	QJDns::Record pubrecord;


### PR DESCRIPTION
- reduced scope of variables
- added initialization member variables
- removed C-style typecasts from QJDNS
- using enum instead of integer